### PR TITLE
Updates based on Stage 2 consensus

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!--#region:status-->
 ## Status
 
-**Stage:** 1  
+**Stage:** 2  
 **Champion:** Ron Buckton ([@rbuckton](https://github.com/rbuckton))  
 
 _For detailed status of this proposal see [TODO](#todo), below._  
@@ -54,15 +54,18 @@ Buffer boundaries are similar to the `^` and `$` anchors, except that they are n
 
 - `\A` &mdash; Matches the start of the input.
 - `\z` &mdash; Matches the end of the input.
-- `\Z` &mdash; A zero-width assertion consisting of an optional newline at the end of the buffer. Equivalent to `(?=\R?\z)`.
+- ~~`\Z` &mdash; A zero-width assertion consisting of an optional newline at the end of the buffer. Equivalent to `(?=\R?\z)`.~~
 
 > NOTE: Requires the `u` or `v` flag, as `\A`, `\z`, and `\Z` are currently just escapes for `A`, `z` and `Z` without the `u` or `v` flag. 
 
 > NOTE: Not supported inside of a character class.
 
+> NOTE: The `\Z` assertion is no longer being considered as part of this proposal as of December 15th, 2021, but has
+> been reserved for possible future use.
+
 For more information about the `v` flag, see https://github.com/tc39/proposal-regexp-set-notation.
 
-For more information about the `\R` escape sequence, see https://github.com/tc39/proposal-regexp-r-escape.
+~~For more information about the `\R` escape sequence, see https://github.com/tc39/proposal-regexp-r-escape.~~
 
 <!--#endregion:syntax-->
 
@@ -109,12 +112,6 @@ re.test("\nbar");       // true
 re.test("baz");         // true
 re.test("baz\n");       // false
 re.test("\nbaz");       // true
-
-// trailing buffer boundary
-const re = /end\Z/u;
-re.test("end");         // true
-re.test("end\n");       // true (optional newline)
-re.test("end\n\n");     // false
 ```
 
 <!--#endregion:examples-->
@@ -143,6 +140,9 @@ re.test("end\n\n");     // false
 
 - October 28, 2021 &mdash; Proposed for Stage 1 ([slides](https://1drv.ms/p/s!AjgWTO11Fk-TkfoSnHYFCoo4mYndTA?e=r0YIxu))
   - Outcome: Advanced to Stage 1
+- December 15, 2021 &mdash; Proposed for Stage 2 ([slides](https://1drv.ms/p/s!AjgWTO11Fk-Tkfs-sKyEtV6B_S-poQ?e=U7ToKV))
+  - Outcome: `\A` and `\z` advanced to Stage 2 (`\Z` did not advance, but will be reserved)
+  - Stage 2 Reviewers: Richard Gibson, Waldemar Horwat
 
 <!--#region:todo-->
 # TODO
@@ -163,7 +163,7 @@ The following is a high-level list of tasks to progress through each stage of th
 
 ### Stage 3 Entrance Criteria
 
-* [ ] [Complete specification text][Specification].  
+* [x] [Complete specification text][Specification].  
 * [ ] Designated reviewers have [signed off][Stage3ReviewerSignOff] on the current spec text.  
 * [ ] The ECMAScript editor has [signed off][Stage3EditorSignOff] on the current spec text.  
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -4,7 +4,7 @@
 <link rel="spec" href="es2015" />
 <pre class="metadata">
 title: Regular Expression Buffer Boundaries for ECMAScript
-stage: 1
+stage: 2
 contributors: Ron Buckton, Ecma International
 </pre>
 
@@ -49,7 +49,6 @@ contributors: Ron Buckton, Ecma International
           `^`
           `$`
           <ins>`\` `A`</ins>
-          <ins>`\` `Z`</ins>
           <ins>`\` `z`</ins>
           `\` `b`
           `\` `B`
@@ -232,6 +231,11 @@ contributors: Ron Buckton, Ecma International
       <emu-note>
         <p>A number of productions in this section are given alternative definitions in section <emu-xref href="#sec-regular-expressions-patterns"></emu-xref>.</p>
       </emu-note>
+      <ins class="block">
+        <emu-note>
+          While the sequence `\Z` is already an error when the `u` (unicode) flag is present, it is reserved for possible future use as an extension of the `\A` and `\z` assertions.
+        </emu-note>
+      </ins>
     </emu-clause>
 
     <emu-clause id="sec-pattern-semantics">
@@ -255,28 +259,6 @@ contributors: Ron Buckton, Ecma International
             1. Assert: _c_ is a Continuation.
             1. Let _e_ be _x_'s _endIndex_.
             1. If _e_ = 0, return _c_(_x_).
-            1. Return ~failure~.
-        </emu-alg>
-
-        <emu-grammar>
-          Assertion :: `\` `Z`
-        </emu-grammar>
-        <emu-alg>
-          1. Returns a new Matcher with parameters (_x_, _c_) that captures nothing and performs the following steps when called:
-            1. Assert: _x_ is a State.
-            1. Assert: _c_ is a Continuation.
-            1. Let _e_ be _x_'s _endIndex_.
-            1. If _e_ = _InputLength_, return _c_(_x_).
-            1. Let _f_ be _e_ + 1.
-            1. Let _ch_ be the character _Input_[_e_].
-            1. Let _cc_ be Canonicalize(_ch_).
-            1. Let _A_ be a CharSet containing the characters &lt;LF&gt;, &lt;VT&gt;, &lt;FF&gt;, &lt;CR&gt;, &lt;NL&gt;, &lt;LS&gt;, and &lt;PS&gt;.
-            1. If there does not exist a member _a_ of _A_ such that Canonicalize(_a_) is _cc_, return ~failure~.
-            1. If _cc_ is the character &lt;CR&gt; and _e_ + 1 &lt; _InputLength_, then
-              1. Let _nextCh_ be the character _Input_[_e_ + 1].
-              1. Let _nextCc_ be Canonicalize(_nextCh_).
-              1. If _nextCc_ is the character &lt;LF&gt;, set _f_ to _f_ + 1.
-            1. If _f_ = _InputLength_, return _c_(_x_).
             1. Return ~failure~.
         </emu-alg>
 
@@ -322,7 +304,6 @@ contributors: Ron Buckton, Ecma International
           `^`
           `$`
           <ins>`\` `A`</ins>
-          <ins>`\` `Z`</ins>
           <ins>`\` `z`</ins>
           `\` `b`
           `\` `B`


### PR DESCRIPTION
This updates the specification and README to reflect the Stage 2 consensus:

- `\Z` was removed but will be reserved for possible future use as an extension to `\A` and `\z` assertions. This is to prevent possible future use of `\Z` with a different meaning which would be confusing given existing implementations of `\A`, `\z`, and `\Z` in other languages/engines.

Fixes #1 