### PR TITLE
Add UnicodeMode to assertions in index.html

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -48,8 +48,8 @@ contributors: Ron Buckton, Ecma International
         Assertion[UnicodeMode, N] ::
           `^`
           `$`
-          <ins>`\` `A`</ins>
-          <ins>`\` `z`</ins>
+          <ins>[+UnicodeMode] `\` `A`</ins>
+          <ins>[+UnicodeMode] `\` `z`</ins>
           `\` `b`
           `\` `B`
           `(` `?` `=` Disjunction[?UnicodeMode, ?N] `)`
@@ -303,8 +303,8 @@ contributors: Ron Buckton, Ecma International
         Assertion[UnicodeMode, N] ::
           `^`
           `$`
-          <ins>`\` `A`</ins>
-          <ins>`\` `z`</ins>
+          <ins>[+UnicodeMode] `\` `A`</ins>
+          <ins>[+UnicodeMode] `\` `z`</ins>
           `\` `b`
           `\` `B`
           [+UnicodeMode] `(` `?` `=` Disjunction[+UnicodeMode, ?N] `)`


### PR DESCRIPTION
Updated regex syntax in index.html to include `[+UnicodeMode]` for both `\A` and `\z`.
